### PR TITLE
Add list of datasets to README rather than Google Spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,53 @@
 
 One of our missions is to unlock the **biodiversity data** managed by the Research Institute for Nature and Forest ([INBO](http://www.inbo.be)): both existing datasets and data collected through our terrestrial and freshwater observatories for the [LifeWatch research infrastructure](http://lifewatch.inbo.be/blog/pages/about.html). The bulk of these data are occurrence and checklist data, which we publish as open, standardized, well-documented, [GBIF-registered](http://www.gbif.org) [Darwin Core Archives](http://en.wikipedia.org/wiki/Darwin_Core_Archive) on our [GBIF Integrated Publishing Toolkit (IPT)](http://data.inbo.be/ipt).
 
-This repository is where we document data publication guidelines and track issues for our published and to be published datasets. Note that this is a work in progress. If you have questions or remarks, [leave an issue](https://github.com/LifeWatchINBO/data-publication/issues), contact us at [@LifeWatchINBO](https://twitter.com/LifeWatchINBO) or opendata@inbo.be.
+This repository is where we document data publication guidelines and track issues for our published and to be published datasets. Note that this is a work in progress. If you have questions or remarks, [leave an issue](https://github.com/inbo/data-publication/issues), contact us at [@LifeWatchINBO](https://twitter.com/LifeWatchINBO) or opendata@inbo.be.
 
 ## Our datasets
 
-* [List of our datasets (published with the IPT)](https://docs.google.com/spreadsheets/d/13qSyBS7mZPYENHjPpgEAJirQ58G3pI9tmtW6gvv2vKk/edit#gid=1267456430)
+### Occurrence datasets
+
+Title (and directory in this repo) | DOI  | 1st publication
+--- | --- | ---
+[Florabank1 - A grid-based database on vascular plant distribution in the northern part of Belgium (Flanders and the Brussels Capital region)](dataset/florabank1-occurrences) | http://doi.org/10.3897/phytokeys.12.2849 | 2011-08-17
+[TestWat - Macroinvertebrates and macrophytes of freshwater bodies in Flanders, Belgium](dataset/testwat-occurrences) | http://doi.org/10.15468/xzpcvv | 2011-08-18
+[Belgian Coccinellidae - Ladybird beetles in Belgium](dataset/belgian-coccinellidae-occurrences) | http://doi.org/10.15468/0refva | 2012-06-05
+[Trekvis - Migratory fishes in the river Scheldt](dataset/trekvis-occurrences) | http://doi.org/10.15468/j9tj7x | 2012-07-19
+[Visherintroductie - Reintroduction of the fishes chub, dace, burbot, and brown trout in Flanders, Belgium](dataset/visherintroductie-occurrences) | http://doi.org/10.15468/dlglrp | 2012-09-27
+[Visdoorgangen - Fish passage places in Flanders, Belgium](dataset/visdoorgangen-occurrences) | http://doi.org/10.15468/92ylpd | 2012-10-03
+[Visfauna - Juvenile and adult fishes in riparian habitats along the river Leie](dataset/visfauna-leie-occurrences) | http://doi.org/10.15468/2wrvbz | 2013-01-10
+[Visfauna - Juvenile and adult fishes in riparian habitats along the river Yser in Flanders, Belgium](dataset/visfauna-ijzer-occurrences) | http://doi.org/10.15468/keplkx | 2013-01-10
+[Glasaalmigratie - Glass eels migration in the river Yser](dataset/glasaalmigratie-occurrences) | http://doi.org/10.15468/cynpxv | 2013-01-10
+[Depletion fishing in the rivers Grote Nete and Kleine Nete in Flanders, Belgium](dataset/depletion-fishing-nete-occurrences) | http://doi.org/10.15468/zan6uj | 2013-05-05
+[Loopkevers Grensmaas - Ground beetles near the river Meuse in Flanders, Belgium](dataset/kevers-grensmaas-occurrences) | http://doi.org/10.15468/hy3pzl | 2013-06-11
+[Saltabel - Orthoptera in Belgium](dataset/saltabel-occurrences) | http://doi.org/10.15468/1rcpsq | 2013-09-13
+[VIS - Fishes in inland waters in Flanders, Belgium](dataset/vis-inland-occurrences) | http://doi.org/10.15468/gzyxyd | 2013-12-20
+[VIS - Fishes in estuarine waters in Flanders, Belgium](dataset/vis-estuarine-occurrences) | http://doi.org/10.15468/estwpt | 2014-04-02
+[Bird tracking - GPS tracking of Lesser Black-backed Gulls and Herring Gulls breeding at the southern North Sea coast](dataset/bird-tracking-gull-occurrences) | http://doi.org/10.15468/02omly | 2014-06-18
+[Watervogels - Wintering waterbirds in Flanders, Belgium](dataset/watervogels-occurrences) | http://doi.org/10.15468/lj0udq | 2014-11-27
+[Broedvogels - Atlas of the breeding birds in Flanders 2000-2002](dataset/broedvogel-atlas-occurrences) | http://doi.org/10.15468/sccg5a | 2015-05-06
+[Invasive species - American bullfrog (Lithobates catesbeianus) in Flanders, Belgium](dataset/invasive-bullfrog-occurrences) | http://doi.org/10.15468/2hqkqn | 2015-09-04
+[Invasive species - Chinese mitten crab (Eriocheir sinensis) in Flanders, Belgium](dataset/invasive-chinese-mitten-crab-occurrences) | http://doi.org/10.15468/eakzzv | 2015-10-30
+[Alien macro-invertebrates in Flanders, Belgium](dataset/alien-macroinvertebrate-occurrences) | http://doi.org/10.15468/xjtfoo | 2016-01-06
+[Vlinderdatabank - Butterflies in Flanders and the Brussels Capital Region, Belgium](dataset/dagvlinders-inbo-occurrences) | http://doi.org/10.15468/njgbmh | 2016-01-13
+[Invasive species - Previously unpublished occurrences in Flanders, Belgium](dataset/invasive-other-occurrences) |  | 
+[Bird tracking - GPS tracking of Western Marsh Harriers breeding near the Belgium-Netherlands border](dataset/bird-tracking-wmh-occurrences) |  | 
+[SAS - Seabirds at sea monitoring in the Belgian part of the North Sea](dataset/sas-occurrences) |  | 
+
+### Sampling-event datasets
+
+Title (and directory in this repo) | DOI  | 1st publication
+--- | --- | ---
+[Zomerganzen - Summering geese management and population counts in Flanders, Belgium](dataset/zomerganzen-events) | http://doi.org/10.15468/a5ubtp | 2016-01-22
+[InboVeg - NICHE-Vlaanderen groundwater related vegetation relevés for Flanders, Belgium](dataset/inboveg-niche-vlaanderen-events) | http://doi.org/10.15468/gouexm | 2016-08-03
+[VIS - Reference freshwater monitoring in Flanders, Belgium (post 2013)](dataset/vis-freshwater-monitoring-events) | http://doi.org/10.15468/klsy8u | 2017-01-10
+[VIS - Estuarine monitoring in Flanders, Belgium (post 2013)](dataset/vis-estuarine-monitoring-events) | http://doi.org/10.15468/jhv16z | 2017-01-20
+
+### Checklist datasets
+
+Title (and directory in this repo) | DOI  | 1st publication
+--- | --- | ---
+[Red list of dragonflies in Flanders, Belgium](dataset/rl-libellen-checklist) | http://doi.org/10.15468/wgegyc | 2014-05-06
 
 ## Standardization
 
@@ -19,7 +61,7 @@ We use a Google Spreadsheet as a working document to compare standardization bet
 
 ## Guidelines
 
-We are trying to document the guidelines we've set ourselves:
+We are trying to document the guidelines we follow. They should be considered drafts:
 
 * [Guide for Darwin Core occurrence data](guidelines/data/occurrence-guide.md)
 * [Guide for IPT metadata](guidelines/metadata/metadata-guide.md)


### PR DESCRIPTION
@DimEvil @stijnvanhoey, rather than maintaining a list of datasets in the [Google Spreadsheet](https://docs.google.com/spreadsheets/d/13qSyBS7mZPYENHjPpgEAJirQ58G3pI9tmtW6gvv2vKk/edit#gid=1267456430), I think we better maintain this within this repo, in the README.

The list now only contains 3 columns, with:

* Title (+ shortname as a link to the directory on GitHub)
* DOI
* First publication date (and they are added in that order)

I don't think we need more info in that list and would like to remove the sheet from the Google Spreadsheet, which I hope to face out completely at some point (when we have whip).

Do you agree?